### PR TITLE
Fix exact search

### DIFF
--- a/bin/search
+++ b/bin/search
@@ -8,6 +8,7 @@ use Symfony\Component\HttpClient\CurlHttpClient;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use TheBrokenTile\BoardGameGeekApi\ObjectBuilder\GameBuilder;
 use TheBrokenTile\BoardGameGeekApi\ObjectBuilder\ObjectBuilder;
+use TheBrokenTile\BoardGameGeekApi\ObjectBuilder\RetryExactSearchBuilder;
 use TheBrokenTile\BoardGameGeekApi\ObjectBuilder\SearchResultBuilder;
 use TheBrokenTile\BoardGameGeekApi\Request\GameRequest;
 use TheBrokenTile\BoardGameGeekApi\Request\SearchRequest;
@@ -20,13 +21,16 @@ if (count($argv) < 2) {
 
 $query = $argv[1];
 
+$searchResultBuilder = new SearchResultBuilder();
+
 $client = new Client(
     new CurlHttpClient(),
     new TagAwareAdapter(
         new FilesystemAdapter(),
     ),
     new ObjectBuilder([
-        new SearchResultBuilder(),
+        $searchResultBuilder,
+        new RetryExactSearchBuilder($searchResultBuilder),
     ]),
     new UrlGenerator(),
 );

--- a/src/BoardGameGeekApi/Client.php
+++ b/src/BoardGameGeekApi/Client.php
@@ -8,6 +8,7 @@ use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use TheBrokenTile\BoardGameGeekApi\ObjectBuilder\ObjectBuilderManagerInterface;
+use TheBrokenTile\BoardGameGeekApi\Request\RetryRequestInterface;
 
 final class Client implements ClientInterface
 {
@@ -47,6 +48,9 @@ final class Client implements ClientInterface
         \assert(\is_string($response));
 
         $thing = $this->builder->build($request, $response);
+        if (0 === $thing->getTotalItems() && $request instanceof RetryRequestInterface && $retryRequest = $request->getRetryRequest()) {
+            return $this->request($retryRequest);
+        }
 
         return new Response($thing);
     }

--- a/src/BoardGameGeekApi/DataTransferObject/Collection.php
+++ b/src/BoardGameGeekApi/DataTransferObject/Collection.php
@@ -10,4 +10,9 @@ final class Collection implements DataTransferObjectInterface
     public string $pubDate;
     /** @var CollectionItem[] */
     public array $items = [];
+
+    public function getTotalItems(): int
+    {
+        return $this->totalItems;
+    }
 }

--- a/src/BoardGameGeekApi/DataTransferObject/DataTransferObject.php
+++ b/src/BoardGameGeekApi/DataTransferObject/DataTransferObject.php
@@ -25,4 +25,9 @@ abstract class DataTransferObject implements DataTransferObjectInterface
     public ?int $maxPlayTime;
     public ?int $minAge;
     public ?GameStatistics $stats;
+
+    public function getTotalItems(): int
+    {
+        return 1;
+    }
 }

--- a/src/BoardGameGeekApi/DataTransferObject/DataTransferObjectInterface.php
+++ b/src/BoardGameGeekApi/DataTransferObject/DataTransferObjectInterface.php
@@ -6,4 +6,5 @@ namespace TheBrokenTile\BoardGameGeekApi\DataTransferObject;
 
 interface DataTransferObjectInterface
 {
+    public function getTotalItems(): int;
 }

--- a/src/BoardGameGeekApi/DataTransferObject/GameResults.php
+++ b/src/BoardGameGeekApi/DataTransferObject/GameResults.php
@@ -9,4 +9,9 @@ final class GameResults implements DataTransferObjectInterface
     public int $total = 0;
     /** @var DataTransferObject[] */
     public array $items = [];
+
+    public function getTotalItems(): int
+    {
+        return $this->total;
+    }
 }

--- a/src/BoardGameGeekApi/DataTransferObject/SearchResults.php
+++ b/src/BoardGameGeekApi/DataTransferObject/SearchResults.php
@@ -8,5 +8,10 @@ final class SearchResults implements DataTransferObjectInterface
 {
     public int $total;
     /** @var SearchItem[] */
-    public array $items;
+    public array $items = [];
+
+    public function getTotalItems(): int
+    {
+        return $this->total;
+    }
 }

--- a/src/BoardGameGeekApi/DataTransferObject/User.php
+++ b/src/BoardGameGeekApi/DataTransferObject/User.php
@@ -31,4 +31,9 @@ final class User implements DataTransferObjectInterface
     public array $hot = [];
     /** @var UserTopItem[] */
     public array $top = [];
+
+    public function getTotalItems(): int
+    {
+        return 1;
+    }
 }

--- a/src/BoardGameGeekApi/ObjectBuilder/CollectionBuilder.php
+++ b/src/BoardGameGeekApi/ObjectBuilder/CollectionBuilder.php
@@ -29,7 +29,7 @@ final class CollectionBuilder extends AbstractObjectBuilder
     /**
      * @return Collection
      */
-    public function build(string $response): DataTransferObjectInterface
+    public function build(string $response, RequestInterface $request): DataTransferObjectInterface
     {
         $collection = new Collection();
         $crawler = new Crawler($response);

--- a/src/BoardGameGeekApi/ObjectBuilder/GameBuilder.php
+++ b/src/BoardGameGeekApi/ObjectBuilder/GameBuilder.php
@@ -24,7 +24,7 @@ final class GameBuilder extends AbstractObjectBuilder
     /**
      * @return GameResults
      */
-    public function build(string $response): DataTransferObjectInterface
+    public function build(string $response, RequestInterface $request): DataTransferObjectInterface
     {
         $results = new GameResults();
         $crawler = new Crawler($response);

--- a/src/BoardGameGeekApi/ObjectBuilder/ObjectBuilder.php
+++ b/src/BoardGameGeekApi/ObjectBuilder/ObjectBuilder.php
@@ -23,7 +23,7 @@ final class ObjectBuilder implements ObjectBuilderManagerInterface
     {
         foreach ($this->builders as $builder) {
             if ($builder->supports($request)) {
-                return $builder->build($response);
+                return $builder->build($response, $request);
             }
         }
 

--- a/src/BoardGameGeekApi/ObjectBuilder/ObjectBuilderInterface.php
+++ b/src/BoardGameGeekApi/ObjectBuilder/ObjectBuilderInterface.php
@@ -113,5 +113,5 @@ interface ObjectBuilderInterface
 
     public function supports(RequestInterface $request): bool;
 
-    public function build(string $response): DataTransferObjectInterface;
+    public function build(string $response, RequestInterface $request): DataTransferObjectInterface;
 }

--- a/src/BoardGameGeekApi/ObjectBuilder/RetryExactSearchBuilder.php
+++ b/src/BoardGameGeekApi/ObjectBuilder/RetryExactSearchBuilder.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheBrokenTile\BoardGameGeekApi\ObjectBuilder;
+
+use TheBrokenTile\BoardGameGeekApi\DataTransferObject\DataTransferObjectInterface;
+use TheBrokenTile\BoardGameGeekApi\DataTransferObject\SearchItem;
+use TheBrokenTile\BoardGameGeekApi\DataTransferObject\SearchResults;
+use TheBrokenTile\BoardGameGeekApi\Request\RetrySearchRequest;
+use TheBrokenTile\BoardGameGeekApi\RequestInterface;
+
+final class RetryExactSearchBuilder implements ObjectBuilderInterface
+{
+    private ObjectBuilderInterface $searchBuilder;
+
+    public function __construct(ObjectBuilderInterface $searchBuilder)
+    {
+        $this->searchBuilder = $searchBuilder;
+    }
+
+    public function supports(RequestInterface $request): bool
+    {
+        return $request instanceof RetrySearchRequest;
+    }
+
+    public function build(string $response, RequestInterface $request): DataTransferObjectInterface
+    {
+        $result = $this->searchBuilder->build($response, $request);
+        \assert($result instanceof SearchResults);
+
+        $result->items = array_values(
+            array_filter(
+                $result->items,
+                static fn (SearchItem $item) => $item->name->value === $request->getParams()[RequestInterface::PARAM_QUERY],
+            ),
+        );
+        $result->total = \count($result->items);
+
+        return $result;
+    }
+}

--- a/src/BoardGameGeekApi/ObjectBuilder/SearchResultBuilder.php
+++ b/src/BoardGameGeekApi/ObjectBuilder/SearchResultBuilder.php
@@ -19,7 +19,7 @@ final class SearchResultBuilder extends AbstractObjectBuilder
         return $request instanceof SearchRequest;
     }
 
-    public function build(string $response): SearchResults
+    public function build(string $response, RequestInterface $request): SearchResults
     {
         $crawler = new Crawler($response);
         $items = $crawler->filter(self::ITEMS)->eq(0);

--- a/src/BoardGameGeekApi/ObjectBuilder/UserBuilder.php
+++ b/src/BoardGameGeekApi/ObjectBuilder/UserBuilder.php
@@ -27,7 +27,7 @@ final class UserBuilder implements ObjectBuilderInterface
      *
      * @return User
      */
-    public function build(string $response): DataTransferObjectInterface
+    public function build(string $response, RequestInterface $request): DataTransferObjectInterface
     {
         $user = new User();
         $crawler = (new Crawler($response))->filter(self::USER)->eq(0);

--- a/src/BoardGameGeekApi/Request/CollectionRequest.php
+++ b/src/BoardGameGeekApi/Request/CollectionRequest.php
@@ -9,10 +9,10 @@ use TheBrokenTile\BoardGameGeekApi\RequestInterface;
 final class CollectionRequest implements RequestInterface
 {
     private string $username;
-    private ?bool $version = null;
-    private ?bool $brief = null;
-    private ?bool $stats = null;
-    /** @var array<string, bool|int|string> */
+    private ?string $version = null;
+    private ?string $brief = null;
+    private ?string $stats = null;
+    /** @var array<string, string> */
     private array $filters = [];
 
     public function __construct(string $username)
@@ -27,17 +27,17 @@ final class CollectionRequest implements RequestInterface
 
     public function getParams(): array
     {
-        return array_merge([
+        return array_filter(array_merge([
             self::PARAM_COLLECTION_USERNAME => $this->username,
             self::PARAM_COLLECTION_VERSION => $this->version,
             self::PARAM_COLLECTION_BRIEF => $this->brief,
             self::PARAM_STATS => $this->stats,
-        ], $this->filters);
+        ], $this->filters));
     }
 
     public function version(): self
     {
-        $this->version = true;
+        $this->version = '1';
 
         return $this;
     }
@@ -48,14 +48,14 @@ final class CollectionRequest implements RequestInterface
      */
     public function brief(): self
     {
-        $this->brief = true;
+        $this->brief = '1';
 
         return $this;
     }
 
     public function stats(): self
     {
-        $this->stats = true;
+        $this->stats = '1';
 
         return $this;
     }
@@ -65,6 +65,16 @@ final class CollectionRequest implements RequestInterface
      */
     public function filter(string $name, $value): self
     {
+        if (\is_bool($value)) {
+            $this->filters[$name] = $value ? '1' : '0';
+
+            return $this;
+        }
+        if (\is_int($value)) {
+            $this->filters[$name] = (string) $value;
+
+            return $this;
+        }
         $this->filters[$name] = $value;
 
         return $this;

--- a/src/BoardGameGeekApi/Request/GameRequest.php
+++ b/src/BoardGameGeekApi/Request/GameRequest.php
@@ -8,13 +8,12 @@ use TheBrokenTile\BoardGameGeekApi\RequestInterface;
 
 final class GameRequest implements RequestInterface
 {
-    /** @var int[] */
-    private array $id;
-    private ?bool $stats = null;
+    private string $id;
+    private ?string $stats = null;
 
     public function __construct(int ...$ids)
     {
-        $this->id = $ids;
+        $this->id = implode(self::PARAM_VALUE_SEPARATOR, $ids);
     }
 
     public function getType(): string
@@ -24,15 +23,15 @@ final class GameRequest implements RequestInterface
 
     public function getParams(): array
     {
-        return [
-            self::PARAM_ID => implode(self::PARAM_VALUE_SEPARATOR, $this->id),
+        return array_filter([
+            self::PARAM_ID => $this->id,
             self::PARAM_STATS => $this->stats,
-        ];
+        ]);
     }
 
     public function stats(): self
     {
-        $this->stats = true;
+        $this->stats = '1';
 
         return $this;
     }

--- a/src/BoardGameGeekApi/Request/RetryRequestInterface.php
+++ b/src/BoardGameGeekApi/Request/RetryRequestInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheBrokenTile\BoardGameGeekApi\Request;
+
+use TheBrokenTile\BoardGameGeekApi\RequestInterface;
+
+interface RetryRequestInterface
+{
+    public function getRetryRequest(): ?RequestInterface;
+}

--- a/src/BoardGameGeekApi/Request/RetrySearchRequest.php
+++ b/src/BoardGameGeekApi/Request/RetrySearchRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheBrokenTile\BoardGameGeekApi\Request;
+
+use TheBrokenTile\BoardGameGeekApi\RequestInterface;
+
+final class RetrySearchRequest implements RequestInterface
+{
+    private RequestInterface $request;
+    /** @var array<string, string> */
+    private array $overwrites;
+
+    /** @param array<string, string> $overwrites */
+    public function __construct(RequestInterface $request, array $overwrites)
+    {
+        $this->request = $request;
+        $this->overwrites = $overwrites;
+    }
+
+    public function getType(): string
+    {
+        return $this->request->getType();
+    }
+
+    public function getParams(): array
+    {
+        return array_merge($this->request->getParams(), $this->overwrites);
+    }
+}

--- a/src/BoardGameGeekApi/Request/SearchRequest.php
+++ b/src/BoardGameGeekApi/Request/SearchRequest.php
@@ -6,15 +6,15 @@ namespace TheBrokenTile\BoardGameGeekApi\Request;
 
 use TheBrokenTile\BoardGameGeekApi\RequestInterface;
 
-final class SearchRequest implements RequestInterface
+final class SearchRequest implements RequestInterface, RetryRequestInterface
 {
     private string $query;
-    private ?bool $exact;
+    private ?string $exact;
 
     public function __construct(string $query, bool $exact = null)
     {
         $this->query = $query;
-        $this->exact = $exact;
+        $this->exact = null === $exact ? null : ($exact ? '1' : '0');
     }
 
     public function getType(): string
@@ -24,10 +24,21 @@ final class SearchRequest implements RequestInterface
 
     public function getParams(): array
     {
-        return [
+        return array_filter([
             self::PARAM_QUERY => $this->query,
             self::PARAM_EXACT => $this->exact,
             self::PARAM_TYPE => self::PARAM_BOARD_GAME,
-        ];
+        ]);
+    }
+
+    public function getRetryRequest(): ?RequestInterface
+    {
+        if ('1' === $this->exact) {
+            return new RetrySearchRequest($this, [
+                self::PARAM_EXACT => '0',
+            ]);
+        }
+
+        return null;
     }
 }

--- a/src/BoardGameGeekApi/Request/UserRequest.php
+++ b/src/BoardGameGeekApi/Request/UserRequest.php
@@ -9,11 +9,11 @@ use TheBrokenTile\BoardGameGeekApi\RequestInterface;
 final class UserRequest implements RequestInterface
 {
     private string $username;
-    private ?bool $buddies = null;
-    private ?bool $guilds = null;
-    private int $page = 1;
-    private ?bool $top = null;
-    private ?bool $hot = null;
+    private ?string $buddies = null;
+    private ?string $guilds = null;
+    private string $page = '1';
+    private ?string $top = null;
+    private ?string $hot = null;
 
     public function __construct(string $username)
     {
@@ -27,47 +27,47 @@ final class UserRequest implements RequestInterface
 
     public function getParams(): array
     {
-        return [
+        return array_filter([
             self::PARAM_USER_NAME => $this->username,
             self::PARAM_USER_BUDDIES => $this->buddies,
             self::PARAM_USER_GUILDS => $this->guilds,
             self::PARAM_PAGE => $this->page,
             self::PARAM_USER_TOP => $this->top,
             self::PARAM_USER_HOT => $this->hot,
-        ];
+        ]);
     }
 
     public function buddies(): self
     {
-        $this->buddies = true;
+        $this->buddies = '1';
 
         return $this;
     }
 
     public function guilds(): self
     {
-        $this->guilds = true;
+        $this->guilds = '1';
 
         return $this;
     }
 
     public function page(int $page): self
     {
-        $this->page = $page;
+        $this->page = (string) $page;
 
         return $this;
     }
 
     public function top(): self
     {
-        $this->top = true;
+        $this->top = '1';
 
         return $this;
     }
 
     public function hot(): self
     {
-        $this->hot = true;
+        $this->hot = '1';
 
         return $this;
     }

--- a/src/BoardGameGeekApi/RequestInterface.php
+++ b/src/BoardGameGeekApi/RequestInterface.php
@@ -111,6 +111,6 @@ interface RequestInterface
 
     public function getType(): string;
 
-    /** @return array<string, null|bool|float|int|string> */
+    /** @return array<string, string> */
     public function getParams(): array;
 }

--- a/src/BoardGameGeekApi/UrlGenerator.php
+++ b/src/BoardGameGeekApi/UrlGenerator.php
@@ -7,12 +7,19 @@ namespace TheBrokenTile\BoardGameGeekApi;
 final class UrlGenerator implements UrlGeneratorInterface
 {
     private const URL = 'https://api.geekdo.com/xmlapi2';
+    private const DEFAULT_VALUE_FIXES = [
+        RequestInterface::PARAM_QUERY => [':', ''],
+    ];
 
     private string $baseUrl;
+    /** @var array<string, string[]> */
+    private array $valueFixes;
 
-    public function __construct(string $baseUrl = self::URL)
+    /** @param array<string, string[]> $valueFixes */
+    public function __construct(string $baseUrl = self::URL, array $valueFixes = self::DEFAULT_VALUE_FIXES)
     {
         $this->baseUrl = $baseUrl;
+        $this->valueFixes = $valueFixes;
     }
 
     public function generate(RequestInterface $request): string
@@ -21,7 +28,26 @@ final class UrlGenerator implements UrlGeneratorInterface
             '%s/%s?%s',
             $this->baseUrl,
             $request->getType(),
-            http_build_query($request->getParams()),
+            http_build_query($this->fixValues($request->getParams())),
         );
+    }
+
+    /**
+     * @param array<string, string> $params
+     *
+     * @return array<string, string>
+     */
+    private function fixValues(array $params): array
+    {
+        foreach ($params as $key => $value) {
+            if (isset($this->valueFixes[$key])) {
+                /** @var string $search */
+                /** @var string $replace */
+                [$search, $replace] = $this->valueFixes[$key];
+                $params[$key] = str_replace($search, $replace, $value);
+            }
+        }
+
+        return $params;
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -44,7 +44,9 @@ final class ClientTest extends TestCase
         $request->getParams()->willReturn([]);
         $request = $request->reveal();
 
-        $thing = $this->prophesize(DataTransferObjectInterface::class)->reveal();
+        $thing = $this->prophesize(DataTransferObjectInterface::class);
+        $thing->getTotalItems()->willReturn(1);
+        $thing = $thing->reveal();
 
         $objectBuilder->build($request, $stringResponse)
             ->shouldBeCalledOnce()

--- a/tests/CollectionBuilderTest.php
+++ b/tests/CollectionBuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TheBrokenTile\Test;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use TheBrokenTile\BoardGameGeekApi\DataTransferObject\Collection;
 use TheBrokenTile\BoardGameGeekApi\DataTransferObject\CollectionItem;
 use TheBrokenTile\BoardGameGeekApi\DataTransferObject\CollectionStatus;
@@ -16,6 +17,7 @@ use TheBrokenTile\BoardGameGeekApi\DataTransferObject\GameStatistics;
 use TheBrokenTile\BoardGameGeekApi\ObjectBuilder\CollectionBuilder;
 use TheBrokenTile\BoardGameGeekApi\Request\CollectionRequest;
 use TheBrokenTile\BoardGameGeekApi\Request\UserRequest;
+use TheBrokenTile\BoardGameGeekApi\RequestInterface;
 
 /**
  * @coversDefaultClass \TheBrokenTile\BoardGameGeekApi\ObjectBuilder\CollectionBuilder
@@ -24,6 +26,8 @@ use TheBrokenTile\BoardGameGeekApi\Request\UserRequest;
  */
 final class CollectionBuilderTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @covers ::supports
      */
@@ -65,7 +69,7 @@ final class CollectionBuilderTest extends TestCase
         $response = file_get_contents(__DIR__.$fixture);
         \assert(\is_string($response));
 
-        $collection = $collectionBuilder->build($response);
+        $collection = $collectionBuilder->build($response, $this->prophesize(RequestInterface::class)->reveal());
         self::assertInstanceOf(Collection::class, $collection);
 
         self::assertSame($totalItems, $collection->totalItems);

--- a/tests/GameBuilderTest.php
+++ b/tests/GameBuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TheBrokenTile\Test;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use TheBrokenTile\BoardGameGeekApi\DataTransferObject\Game;
 use TheBrokenTile\BoardGameGeekApi\DataTransferObject\GameLink;
 use TheBrokenTile\BoardGameGeekApi\DataTransferObject\GameName;
@@ -14,6 +15,7 @@ use TheBrokenTile\BoardGameGeekApi\DataTransferObject\GameStatistics;
 use TheBrokenTile\BoardGameGeekApi\ObjectBuilder\GameBuilder;
 use TheBrokenTile\BoardGameGeekApi\Request\GameRequest;
 use TheBrokenTile\BoardGameGeekApi\Request\SearchRequest;
+use TheBrokenTile\BoardGameGeekApi\RequestInterface;
 
 /**
  * @coversDefaultCLass \TheBrokenTile\BoardGameGeekApi\ObjectBuilder\GameBuilder
@@ -22,6 +24,8 @@ use TheBrokenTile\BoardGameGeekApi\Request\SearchRequest;
  */
 final class GameBuilderTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @covers ::supports
      */
@@ -69,11 +73,10 @@ final class GameBuilderTest extends TestCase
         $response = file_get_contents(__DIR__.$fixture);
         \assert(\is_string($response));
 
-        $results = $builder->build($response);
+        $results = $builder->build($response, $this->prophesize(RequestInterface::class)->reveal());
         self::assertSame($expectedTotal, $results->total);
         $game = $results->items[$gameIndex];
         \assert($game instanceof Game);
-
         self::assertSame($expectedId, $game->id);
         self::assertSame($expectedImage, $game->image);
         self::assertSame($expectedThumbnail, $game->thumbnail);

--- a/tests/ObjectBuilderTest.php
+++ b/tests/ObjectBuilderTest.php
@@ -36,7 +36,7 @@ final class ObjectBuilderTest extends TestCase
             ->willReturn(true)
         ;
         $supportedBuilder
-            ->build($stringResponse)
+            ->build($stringResponse, $request)
             ->willReturn($expectedResponse)
         ;
 
@@ -47,7 +47,7 @@ final class ObjectBuilderTest extends TestCase
             ->willReturn(false)
         ;
         $notSupportedBuilder
-            ->build($stringResponse)
+            ->build($stringResponse, $request)
             ->shouldNotBeCalled()
         ;
 
@@ -57,7 +57,7 @@ final class ObjectBuilderTest extends TestCase
             ->shouldNotBeCalled()
         ;
         $secondNotSupportedBuilder
-            ->build($stringResponse)
+            ->build($stringResponse, $request)
             ->shouldNotBeCalled()
         ;
 

--- a/tests/RetryExactSearchBuilderTest.php
+++ b/tests/RetryExactSearchBuilderTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheBrokenTile\Test;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use TheBrokenTile\BoardGameGeekApi\DataTransferObject\GameName;
+use TheBrokenTile\BoardGameGeekApi\DataTransferObject\SearchItem;
+use TheBrokenTile\BoardGameGeekApi\DataTransferObject\SearchResults;
+use TheBrokenTile\BoardGameGeekApi\ObjectBuilder\ObjectBuilderInterface;
+use TheBrokenTile\BoardGameGeekApi\ObjectBuilder\RetryExactSearchBuilder;
+use TheBrokenTile\BoardGameGeekApi\Request\RetrySearchRequest;
+use TheBrokenTile\BoardGameGeekApi\Request\SearchRequest;
+use TheBrokenTile\BoardGameGeekApi\RequestInterface;
+
+/**
+ * @coversDefaultClass \TheBrokenTile\BoardGameGeekApi\ObjectBuilder\RetryExactSearchBuilder
+ *
+ * @internal
+ */
+final class RetryExactSearchBuilderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private const RESPONSE = 'response';
+
+    /**
+     * @covers ::supports
+     */
+    public function testSupports(): void
+    {
+        $builder = new RetryExactSearchBuilder($this->prophesize(ObjectBuilderInterface::class)->reveal());
+
+        self::assertTrue($builder->supports(new RetrySearchRequest($this->prophesize(RequestInterface::class)->reveal(), [])));
+
+        self::assertFalse($builder->supports(new SearchRequest('search')));
+    }
+
+    /**
+     * @covers ::build
+     * @dataProvider dataProvider
+     */
+    public function testBuild(string $query, SearchResults $searchResults, SearchResults $expectedResults): void
+    {
+        $searchBuilder = $this->prophesize(ObjectBuilderInterface::class);
+        $searchBuilder->build(self::RESPONSE, Argument::type(RequestInterface::class))
+            ->willReturn($searchResults)
+        ;
+        $searchBuilder = $searchBuilder->reveal();
+
+        $request = $this->prophesize(RequestInterface::class);
+        $request->getParams()->willReturn([
+            RequestInterface::PARAM_QUERY => $query,
+        ]);
+        $request = $request->reveal();
+
+        $builder = new RetryExactSearchBuilder($searchBuilder);
+
+        self::assertEquals($expectedResults, $builder->build(self::RESPONSE, $request));
+    }
+
+    /**
+     * @return array<string, mixed[]>
+     */
+    public function dataProvider(): array
+    {
+        $searchItem = new SearchItem(1, SearchItem::TYPE_BOARD_GAME, new GameName(1, GameName::TYPE_PRIMARY, 'test name'), 2022);
+        $secondItem = new SearchItem(2, SearchItem::TYPE_BOARD_GAME, new GameName(2, GameName::TYPE_ALTERNATE, 'test'), 2022);
+
+        return [
+            'first result is exact' => [
+                'query' => 'test name',
+                'searchResults' => $this->buildSearchResults([
+                    $searchItem,
+                    $secondItem,
+                ]),
+                'expectedResult' => $this->buildSearchResults([$searchItem]),
+            ],
+            'second result is exact' => [
+                'query' => 'test name',
+                'searchResults' => $this->buildSearchResults([
+                    $secondItem,
+                    $searchItem,
+                ]),
+                'expectedResult' => $this->buildSearchResults([$searchItem]),
+            ],
+        ];
+    }
+
+    /**
+     * @param SearchItem[] $items
+     */
+    private function buildSearchResults(array $items): SearchResults
+    {
+        $results = new SearchResults();
+        $results->items = $items;
+        $results->total = \count($items);
+
+        return $results;
+    }
+}

--- a/tests/SearchResultBuilderTest.php
+++ b/tests/SearchResultBuilderTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace TheBrokenTile\Test;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use TheBrokenTile\BoardGameGeekApi\DataTransferObject\GameName;
 use TheBrokenTile\BoardGameGeekApi\DataTransferObject\SearchItem;
 use TheBrokenTile\BoardGameGeekApi\ObjectBuilder\SearchResultBuilder;
 use TheBrokenTile\BoardGameGeekApi\Request\GameRequest;
 use TheBrokenTile\BoardGameGeekApi\Request\SearchRequest;
+use TheBrokenTile\BoardGameGeekApi\RequestInterface;
 
 /**
  * @coversDefaultClass \TheBrokenTile\BoardGameGeekApi\ObjectBuilder\SearchResultBuilder
@@ -18,6 +20,8 @@ use TheBrokenTile\BoardGameGeekApi\Request\SearchRequest;
  */
 final class SearchResultBuilderTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @covers ::supports
      */
@@ -44,7 +48,7 @@ final class SearchResultBuilderTest extends TestCase
         \assert(\is_string($response));
         $builder = new SearchResultBuilder();
 
-        $searchResults = $builder->build($response);
+        $searchResults = $builder->build($response, $this->prophesize(RequestInterface::class)->reveal());
         self::assertSame($expectedTotal, $searchResults->total);
         self::assertCount($expectedTotal, $searchResults->items);
 

--- a/tests/UrlGeneratorTest.php
+++ b/tests/UrlGeneratorTest.php
@@ -66,6 +66,10 @@ final class UrlGeneratorTest extends TestCase
                 'https://api.geekdo.com/xmlapi2/user?name=tazzadar1337&page=1',
                 new UserRequest('tazzadar1337'),
             ],
+            'trim semicolons' => [
+                'https://api.geekdo.com/xmlapi2/search?query=Doomtown+Reloaded&exact=1&type=boardgame',
+                new SearchRequest('Doomtown: Reloaded', true),
+            ],
         ];
     }
 }

--- a/tests/UserBuilderTest.php
+++ b/tests/UserBuilderTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace TheBrokenTile\Test\BoardGameGeekApi\ObjectBuilder;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use TheBrokenTile\BoardGameGeekApi\DataTransferObject\User;
 use TheBrokenTile\BoardGameGeekApi\DataTransferObject\UserBuddy;
 use TheBrokenTile\BoardGameGeekApi\DataTransferObject\UserHotItem;
 use TheBrokenTile\BoardGameGeekApi\ObjectBuilder\UserBuilder;
 use TheBrokenTile\BoardGameGeekApi\Request\SearchRequest;
 use TheBrokenTile\BoardGameGeekApi\Request\UserRequest;
+use TheBrokenTile\BoardGameGeekApi\RequestInterface;
 
 /**
  * @coversDefaultClass \TheBrokenTile\BoardGameGeekApi\ObjectBuilder\UserBuilder
@@ -19,6 +21,8 @@ use TheBrokenTile\BoardGameGeekApi\Request\UserRequest;
  */
 final class UserBuilderTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @covers ::suppports
      */
@@ -39,7 +43,7 @@ final class UserBuilderTest extends TestCase
         $response = file_get_contents(__DIR__.'/fixtures/user.xml');
         \assert(\is_string($response));
 
-        $user = $userBuilder->build($response);
+        $user = $userBuilder->build($response, $this->prophesize(RequestInterface::class)->reveal());
         self::assertInstanceOf(User::class, $user);
         self::assertSame(844486, $user->id);
         self::assertSame('tazzadar1337', $user->name);


### PR DESCRIPTION

- `https://api.geekdo.com/xmlapi2/search?query=Doomtown:%20Reloaded&type=boardgame&exact=1` doesn't return results
- `https://api.geekdo.com/xmlapi2/search?query=Doomtown:%20Reloaded&type=boardgame` doesn't either
- `https://api.geekdo.com/xmlapi2/search?query=Doomtown%20Reloaded&type=boardgame` but stripping the `:` returns the game in a non-exact search.

The solution: 
Add a retry mechanism, currently only for search requessts - if a search with `exact=1` returns 0 results, try again without `exact=1` and reiterate over the results to try and match the results' names' with the name from the  `query`
